### PR TITLE
Move title into uiParams of indicator list

### DIFF
--- a/docs/demos/indicator/list.js
+++ b/docs/demos/indicator/list.js
@@ -29,9 +29,9 @@ class IndicatorListDemo1 extends React.Component<PrimitiveTypes<boolean>> {
         <IndicatorList
           refId={new RefId("indicator-list")}
           value={value}
-          title={(value:any) => (<a href="https://ant.design">{value.name}</a>)}
           uiParams={{
             avatar: (value:any) => (<Avatar src={value.avatar} />),
+            title: (value:any) => (<a href="https://ant.design">{value.name}</a>),
             description: () => ('Canner Indicator List Demo'),
             content: () => (<div>Content</div>)
           }}

--- a/packages/antd-indicator-list/src/index.js
+++ b/packages/antd-indicator-list/src/index.js
@@ -6,9 +6,9 @@ import { List } from 'antd';
 import type {IndicatorDefaultProps} from 'types/IndicatorDefaultProps';
 
 type Props = IndicatorDefaultProps & {
-  title: (value: any) => React.Node,
   uiParams: {
     avatar: (value: any) => React.Node,
+    title: (value: any) => React.Node,
     description: (value:any) => React.Node,
     content: (value: any) => React.Node
   }
@@ -16,8 +16,9 @@ type Props = IndicatorDefaultProps & {
 
 const getRandomKey = () => (Math.random().toString(36).substr(2, 10));
 
-const IndicatorList = ({ value, title, uiParams: {
+const IndicatorList = ({ value, uiParams: {
   avatar,
+  title,
   description,
   content
 } }: Props) => {


### PR DESCRIPTION
The title should be inside the uiParams prop.